### PR TITLE
add e2e test / fix for test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,10 +76,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -175,6 +201,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +276,12 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -290,6 +343,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -355,6 +438,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +479,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
@@ -401,9 +510,11 @@ dependencies = [
 name = "timezone_translator"
 version = "0.2.0"
 dependencies = [
+ "assert_cmd",
  "chrono",
  "chrono-tz",
  "clap",
+ "predicates",
  "regex",
  "thiserror",
 ]
@@ -419,6 +530,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
+assert_cmd = "2.0"
 chrono = "0.4"
 chrono-tz = "0.9"
 clap = "4.5"
+predicates = "3.0"
 regex = "1.10.6"
 thiserror = "1.0.63"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,193 @@ fn main() {
     .convert();
 
     match date_time_mapped {
-        Ok(mapped) => println!("{}", mapped),
-        Err(e) => eprintln!("{}", e),
+        Ok(mapped) => {
+            println!("{}", mapped);
+            exit(0);
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use predicates::prelude::*;
+
+    /// This test verifies that the program can correctly convert a given time
+    /// from one timezone (America/New_York) to another (UTC).
+    #[test]
+    fn converts_time_from_new_york_to_utc() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&[
+            "-T",
+            "2024-01-01 12:00:00",
+            "-f",
+            "America/New_York",
+            "-t",
+            "UTC",
+        ]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-01-01 17:00:00 UTC"));
+    }
+
+    #[test]
+    fn converts_time_with_no_timezone() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&["-T", "2024-01-01 12:00:00"]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-01-01 12:00:00"));
+    }
+
+    /// This test verifies that the program correctly converts the given time
+    /// from UTC to the specified timezone (Asia/Tokyo) and returns the
+    /// corresponding standard time.
+    ///
+    /// Specifically, it checks that the output is not just the input timezone information,
+    /// but properly represents the standard time in the target timezone (JST in this case).
+    #[test]
+    fn converts_time_from_utc_to_tokyo() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&["-T", "2024-01-01 12:00:00", "-f", "UTC", "-t", "Asia/Tokyo"]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-01-01 21:00:00 JST"));
+    }
+
+    /// This test verifies that the program can correctly handle input provided
+    /// in the ISO 8601 format. ISO 8601 is an international standard for
+    /// date and time representation, and it typically takes the form
+    /// "YYYY-MM-DDTHH:MM:SS" (e.g., "2024-01-01T12:00:00").
+    ///
+    /// The test ensures that the program accurately parses the date and time
+    /// from this format and converts it to the specified target timezone (UTC).
+    ///
+    /// For more details about ISO 8601 format, refer to the
+    /// [Wikipedia article](https://en.wikipedia.org/wiki/ISO_8601).
+    #[test]
+    fn handles_iso_8601_format() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&[
+            "-T",
+            "2024-01-01T12:00:00",
+            "-f",
+            "America/New_York",
+            "-t",
+            "UTC",
+        ]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-01-01 17:00:00 UTC"));
+    }
+
+    /// This test checks the program's handling of ambiguous times caused by
+    /// daylight saving time (DST) changes. When DST ends, clocks are set back
+    /// one hour, resulting in a repeated hour that can be ambiguous.
+    /// This test uses the "earliest" strategy, which means that the program
+    /// should select the first occurrence of the ambiguous time.
+    ///
+    /// For example, on November 3, 2024, in the "America/New_York" timezone,
+    /// the time "01:30:00" can occur twice—once before the DST ends and once after.
+    /// This test ensures that the program correctly handles this situation
+    /// by selecting the earlier occurrence of "01:30:00".
+    #[test]
+    fn handles_ambiguous_time_with_earliest_strategy() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&[
+            "--time",
+            "2024-11-03 01:30:00",
+            "--from",
+            "America/New_York",
+            "--to",
+            "UTC",
+        ]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-11-03 05:30:00 UTC"));
+    }
+
+    /// This test verifies the program's handling of ambiguous times due to
+    /// daylight saving time (DST) changes, specifically using the "latest" strategy.
+    /// When DST ends and clocks are set back one hour, an ambiguous time can occur
+    /// twice. This strategy ensures that the program selects the second occurrence
+    /// of the ambiguous time.
+    ///
+    /// For example, on November 3, 2024, in the "America/New_York" timezone,
+    /// the time "01:30:00" occurs twice. The first occurrence happens during
+    /// DST, and the second occurrence happens after DST ends. This test confirms
+    /// that the program correctly handles this situation by selecting the later
+    /// occurrence of "01:30:00".
+    #[test]
+    fn handles_ambiguous_time_with_latest_strategy() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&[
+            "--time",
+            "2024-11-03 01:30:00",
+            "--from",
+            "America/New_York",
+            "--to",
+            "UTC",
+            "--ambiguous-time-strategy",
+            "latest",
+        ]);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("2024-11-03 06:30:00 UTC"));
+    }
+
+    /// This test validates that the program correctly identifies
+    /// and reports an error when an invalid "from" timezone is provided.
+    #[test]
+    fn fails_with_invalid_from_timezone() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&["-T", "2024-01-01 12:00:00", "-f", "NOT_EXIST", "-t", "UTC"]);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("Validation Error"));
+    }
+
+    /// This test checks that the program correctly identifies
+    /// and reports an error when an invalid "to" timezone is provided.
+    #[test]
+    fn fails_with_invalid_to_timezone() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&["-T", "2024-01-01 12:00:00", "-f", "UTC", "-t", "NOT_EXIST"]);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("Validation Error"));
+    }
+
+    /// This test verifies that the program correctly handles cases where the resulting
+    /// time does not exist due to daylight saving time (DST) transitions. Specifically,
+    /// during the spring transition, clocks are set forward one hour, causing a gap in time
+    /// where certain times do not exist.
+    ///
+    /// For example, on March 10, 2024, in the "America/New_York" timezone, the local time
+    /// skips from 02:00:00 to 03:00:00, meaning that any time between 02:00:00 and 02:59:59
+    /// does not exist on that day. This test checks that the program correctly identifies
+    /// this scenario and returns an appropriate error, ensuring robust handling of such
+    /// edge cases.
+    ///
+    /// The expected behavior is for the program to detect the non-existent time and
+    /// provide a clear error message indicating the issue.
+    #[test]
+    fn fails_nonexistent_time_due_to_dst() {
+        let mut cmd = Command::cargo_bin("timezone_translator").unwrap();
+        cmd.args(&[
+            "--time",
+            "2024-03-10 02:30:00",
+            "--from",
+            "America/New_York",
+            "--to",
+            "America/Los_Angeles",
+        ]);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("Translation Error"));
     }
 }

--- a/src/validator/validation_error.rs
+++ b/src/validator/validation_error.rs
@@ -1,13 +1,13 @@
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub(crate) enum ValidationError {
-    #[error("Invalid time format found: {0} (expected: YYYY-MM-DD hh:mm:ss)")]
+    #[error("Validation Error: Invalid time format found. {0} (expected: YYYY-MM-DD hh:mm:ss)")]
     TimeFormat(String),
 
     #[error(
-        "Invalid timezone found: {0}. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html"
+        "Validation Error: Invalid timezone found {0}. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html"
     )]
     Timezone(String),
 
-    #[error("Invalid ambiguous time strategy found: {ambiguous_time_strategy} (expected: earliest, latest)")]
+    #[error("Validation Error: Invalid ambiguous time strategy found. {ambiguous_time_strategy} (expected: earliest, latest)")]
     AmbiguousTimeStrategy { ambiguous_time_strategy: String },
 }


### PR DESCRIPTION
## Overview
adding End-to-End test for this repository with `assert_cmd` and `predicates`
(you can check versions with `Cargo.toml`)

## E2E Test
Our End-to-End test checks how tzt behave with input especially corner case. such as ...

- handles_ambiguous_time_with_latest_strategy
- fails_nonexistent_time_due_to_dst

this feature is also written in README.

## Fixing
Running End-to-End test, i found some case we do not expected.

```shell
---- tests::test_error_handling_translation_error stdout ----
thread 'tests::test_error_handling_translation_error' panicked at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5:
Unexpected success
command=`"/Users/shunsuke.tsuchiya/Hobby/timezone_translator/target/debug/timezone_translator" "--time" "2024-03-10 02:30:00" "--from" "America/New_York" "--to" "America/Los_Angeles"`
code=0
stdout=""
stderr="Translation Error: Output time and timezone does not exist. Please check DST rules.\n"

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_error_handling_translation_error

test result: FAILED. 36 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

error: test failed, to rerun pass `--bin timezone_translator`
```

in this case, we expected output value is 1 (err), but our command show 0.
`src/main.rs` line 37-38 causes this problem, and i fixed.


In the next case, we expected output should contain "Validation Error" because of consistency, but not show that.

```shell
failures:

---- tests::test_fail_not_found_from_timezone stdout ----
thread 'tests::test_fail_not_found_from_timezone' panicked at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5:
Unexpected stderr, failed var.contains(Validation Error)
├── var: Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html
└── var as str: Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html

command=`"/Users/shunsuke.tsuchiya/Hobby/timezone_translator/target/debug/timezone_translator" "-T" "2024-01-01 12:00:00" "-f" "NOT_EXIST" "-t" "UTC"`
code=1
stdout=""
stderr="Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html\n"

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_fail_not_found_from_timezone

test result: FAILED. 37 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s
```

I also fixed this problem.


