### PR TITLE
Version up to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "tzt"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tzt"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "simple command-line utility that converts a given time from one timezone to another."

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To install the binary, you can use the following command.
 ```bash
 sudo curl -L -o \
 	/usr/local/bin/tzt \
-	https://github.com/shunsock/timezone_translator/releases/download/v0.1.0/timezone_translator &&\
+	https://github.com/shunsock/timezone_translator/releases/download/v0.3.0/timezone_translator &&\
   sudo chmod +x /usr/local/bin/tzt
 ```
 


### PR DESCRIPTION
## Announce
i am exiting to announce that tzt was published in `crates.io` 🎉
https://crates.io/crates/tzt

Following information is changing log for new version `tzt`.

## 💥 Breaking Changes
https://github.com/shunsock/timezone_translator/pull/34

Implemented feature to read local timezone AS STRING (not offset)
Added tests to ensure the new functionality works as expected.

new version interpret timezone as string because it read following

TZ variable in environment variable
- `/etc/localtime`
- `/etc/timezone`

If tz translator fails to correct timezone from above sources, it returns panic.

## Bug Fix
https://github.com/shunsock/timezone_translator/pull/41
I added e2e test for this repository with assert_cmd and predicates.
Running End-to-End test, i found some case we do not expected.

```shell
---- tests::test_error_handling_translation_error stdout ----
thread 'tests::test_error_handling_translation_error' panicked at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5:
Unexpected success
command=`"/Users/shunsuke.tsuchiya/Hobby/timezone_translator/target/debug/timezone_translator" "--time" "2024-03-10 02:30:00" "--from" "America/New_York" "--to" "America/Los_Angeles"`
code=0
stdout=""
stderr="Translation Error: Output time and timezone does not exist. Please check DST rules.\n"

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_error_handling_translation_error

test result: FAILED. 36 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

error: test failed, to rerun pass `--bin timezone_translator`
in this case, we expected output value is 1 (err), but our command show 0.
src/main.rs line 37-38 causes this problem, and i fixed.
```

In the next case, we expected output should contain "Validation Error" because of consistency, but not show that.

```shell
failures:

---- tests::test_fail_not_found_from_timezone stdout ----
thread 'tests::test_fail_not_found_from_timezone' panicked at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/ops/function.rs:250:5:
Unexpected stderr, failed var.contains(Validation Error)
├── var: Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html
└── var as str: Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html

command=`"/Users/shunsuke.tsuchiya/Hobby/timezone_translator/target/debug/timezone_translator" "-T" "2024-01-01 12:00:00" "-f" "NOT_EXIST" "-t" "UTC"`
code=1
stdout=""
stderr="Invalid timezone found: NOT_EXIST. @see https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html\n"

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_fail_not_found_from_timezone

test result: FAILED. 37 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s
```

I also fixed this problem.

## Update Library
all of these updates are minor version up and i checked we will not be affected.

clap: 4.5.13
https://github.com/shunsock/timezone_translator/pull/40

Bump regex:  1.10.6 
https://github.com/shunsock/timezone_translator/pull/39

Bump regex from 1.10.6 
https://github.com/shunsock/timezone_translator/pull/39