### PR TITLE
docs: crate ごとの README とアーキテクチャ概要 (5/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Options:
           Print version
 ```
 
+## Architecture
+This project is a Cargo workspace following clean architecture.
+Each crate has its own README describing its background, purpose, and examples.
+
+| Crate | Role | README |
+|-------|------|--------|
+| `domain` | Value objects that make invalid inputs unrepresentable | [crates/domain](crates/domain/README.md) |
+| `usecase` | The timezone translation operation itself (DST handling) | [crates/usecase](crates/usecase/README.md) |
+| `infrastructure` | Detects the local timezone from the running system | [crates/infrastructure](crates/infrastructure/README.md) |
+| `presentation` | CLI definition, input parsing, and output | [crates/presentation](crates/presentation/README.md) |
+| `tzt` (root) | Thin binary that calls `presentation::run()` | this file |
+
+Dependencies flow one way: `presentation -> usecase -> domain`, with
+`infrastructure` used only by `presentation` for default values.
+
 ## Dependencies
 This project requires the following dependencies:
 

--- a/crates/domain/README.md
+++ b/crates/domain/README.md
@@ -1,0 +1,72 @@
+# domain
+
+tzt のドメイン層。
+タイムゾーン変換という問題を、型で表現するクレートです。
+
+## 概要
+
+バリューオブジェクト (VO) だけを置いています。
+ロジックの正しさを、型の存在で保証します。
+
+| 型 | 意味 |
+|----|------|
+| `ConversionTime` | 変換対象の壁時計時刻 |
+| `SourceTimezone` | 入力時刻が属するタイムゾーン |
+| `TargetTimezone` | 変換先のタイムゾーン |
+| `AmbiguousTimeStrategy` | 曖昧な時刻の解決方針 (earliest / latest) |
+| `TranslationRequest` | 上記4つの集約。検証済みの変換リクエスト |
+
+## 背景
+
+かつて入力検証は、presentation 層の関数群に散らばっていました。
+「検証済みかどうか」は型に現れませんでした。
+`Tz` を2つ取る関数では、from と to を入れ替えてもコンパイルが通りました。
+
+## 目的
+
+不正な状態を、型で表現不可能にすること。
+Make Illegal States Unrepresentable.
+
+## 手法
+
+**Parse, don't validate.**
+
+各 VO は `FromStr` でしか構築できません。
+構築できた = 検証を通った、が型レベルで成立します。
+
+`SourceTimezone` と `TargetTimezone` は別の型です。
+取り違えはコンパイルエラーになります。
+
+各 VO は自分のパースエラー型を持ちます。
+ユーザー向けメッセージはエラー型に同居しています。
+
+## 処理の事例
+
+```rust
+use domain::{
+    AmbiguousTimeStrategy, ConversionTime,
+    SourceTimezone, TargetTimezone, TranslationRequest,
+};
+
+// 文字列から VO を構築する。失敗はエラー型で返る
+let time: ConversionTime = "2024-01-01 12:00:00".parse()?;
+let source: SourceTimezone = "America/New_York".parse()?;
+let target: TargetTimezone = "UTC".parse()?;
+let strategy: AmbiguousTimeStrategy = "earliest".parse()?;
+
+// すべて揃ったときだけリクエストが作れる
+let request = TranslationRequest::new(time, source, target, strategy);
+```
+
+受理する時刻形式は3つです。
+
+- `2024-01-01 12:00:00`
+- `2024-01-01T12:00:00` (ISO 8601)
+- `2024-01-01` (00:00:00 を補完)
+
+形式の定義は `conversion_time.rs` の `ACCEPTED_FORMATS` テーブルにあります。
+
+## 依存
+
+他レイヤーに依存しません。
+chrono / chrono-tz / regex / thiserror のみを使います。

--- a/crates/infrastructure/README.md
+++ b/crates/infrastructure/README.md
@@ -1,0 +1,51 @@
+# infrastructure
+
+tzt のインフラ層。
+実行中のシステムから、ローカルタイムゾーン名を検出します。
+
+## 概要
+
+公開するのは `provide_local_timezone_string()` 1つです。
+`"Asia/Tokyo"` のような IANA 名を `String` で返します。
+
+## 背景
+
+tzt は `--from` / `--to` を省略できます。
+省略時のデフォルトは「いまいる場所のタイムゾーン」です。
+
+しかし Unix システムにその答えの置き場所は複数あります。
+環境・ディストリビューションによって、どれが使えるかが違います。
+
+## 目的
+
+「システムに聞く」という副作用をこの層に閉じ込めること。
+domain / usecase を環境の事情から自由に保つこと。
+
+## 手法
+
+3つの情報源を、信頼できる順に試します。
+
+1. 環境変数 `TZ`
+2. `/etc/localtime` のシンボリックリンク先 (zoneinfo パスから抽出)
+3. `/etc/timezone` の中身 (Debian 系)
+
+実装は `or_else` チェーンです。
+優先順位がコードの字面と一致します。
+
+すべて失敗した場合は panic します。
+デフォルト値を提供できない以上、起動を続ける意味がないためです。
+
+## 処理の事例
+
+```rust
+use infrastructure::provide_local_timezone_string;
+
+// TZ=Asia/Tokyo が設定された環境なら
+let local = provide_local_timezone_string();
+// => "Asia/Tokyo"
+```
+
+## 依存
+
+他レイヤーに依存しません。
+std のみで動きます (テストのみ regex を使用)。

--- a/crates/presentation/README.md
+++ b/crates/presentation/README.md
@@ -1,0 +1,57 @@
+# presentation
+
+tzt のプレゼンテーション層。
+CLI との境界を担います。
+
+## 概要
+
+公開するのは `run() -> ExitCode` 1つです。
+ルートの `tzt` バイナリは、これを呼ぶだけです。
+
+内部は2つのモジュールに分かれます。
+
+| モジュール | 責務 |
+|-----------|------|
+| `command` | clap によるコマンド定義と引数の受け取り |
+| `validator` | 文字列を domain の VO へ写す |
+
+## 背景
+
+CLI の関心事 (フラグ名、ヘルプ文、終了コード、エラー表示) は変わりやすいものです。
+変換ロジックと混ざると、どちらの変更も難しくなります。
+
+## 目的
+
+「外界との会話」をこの層に閉じ込めること。
+domain / usecase に文字列や clap を持ち込ませないこと。
+
+## 手法
+
+処理は一直線です。
+
+1. `receive_user_input()` — clap で引数を受け取る
+2. `validate_command_options()` — 各文字列を `.parse()` で VO に写す
+3. `TimezoneTranslator::new(request).convert()` — usecase に委譲
+4. 結果を stdout / stderr に出し分け、`ExitCode` を返す
+
+検証ロジックはこの層にありません。
+`.parse()` の向こう側、domain の `FromStr` がすべてを担います。
+
+`--from` / `--to` のデフォルト値には、起動時に infrastructure から
+取得したローカルタイムゾーンを渡します。
+
+## 処理の事例
+
+```
+$ tzt -T "2024-01-01 12:00:00" -f UTC -t Asia/Tokyo
+2024-01-01 21:00:00 JST
+
+$ tzt -T "bad input"
+Validation Error: Invalid time format found. bad input (expected: YYYY-MM-DD hh:mm:ss)
+# 終了コード 1
+```
+
+## 依存
+
+domain / usecase / infrastructure のすべてに依存する、唯一の層です。
+依存方向は常にこの層から下へ向かいます。

--- a/crates/usecase/README.md
+++ b/crates/usecase/README.md
@@ -1,0 +1,54 @@
+# usecase
+
+tzt のユースケース層。
+「時刻をタイムゾーン間で変換する」操作そのものを担います。
+
+## 概要
+
+公開するのは `TimezoneTranslator` 1つです。
+入力は `domain::TranslationRequest`、出力は `Result<DateTime<Tz>, TranslationError>` です。
+
+## 背景
+
+タイムゾーン変換は単純な足し算ではありません。
+DST (夏時間) の切り替わりで、2つの特殊ケースが生まれます。
+
+1. **曖昧な時刻** — DST 終了日は同じ壁時計時刻が2回現れる
+2. **存在しない時刻** — DST 開始日は時計が飛び、間の時刻が消える
+
+この分岐の扱いが、このクレートの存在理由です。
+
+## 目的
+
+変換ロジックを1箇所に集めること。
+CLI やシステム環境の事情から切り離すこと。
+
+## 手法
+
+入力は検証済みの `TranslationRequest` だけを受け取ります。
+このクレートに文字列検証はありません。
+
+chrono の `LocalResult` の3分岐をそのまま写し取ります。
+
+- `Single` — 一意に決まる。そのまま変換
+- `Ambiguous` — リクエストの戦略 (earliest / latest) で選ぶ
+- `None` — `TranslationError::NonexistentTime` を返す
+
+失敗は `Result` で呼び出し側に強制します (鉄道指向)。
+
+## 処理の事例
+
+```rust
+use usecase::TimezoneTranslator;
+
+// New York 2024-11-03 01:30 は DST 終了で2回現れる曖昧な時刻
+let request = /* domain::TranslationRequest (strategy: latest) */;
+
+let translated = TimezoneTranslator::new(request).convert()?;
+// => 2024-11-03 06:30:00 UTC (2回目の 01:30 を採用)
+```
+
+## 依存
+
+domain にのみ依存します (+ chrono / chrono-tz / thiserror)。
+infrastructure や presentation を知りません。


### PR DESCRIPTION
## Background

リファクタ計画の最終弾です (#111 #112 #113 #114 の続き)。

refactor.md の「ガイドを増やす」を実施します:

- crate ごとに README を作る
- 概要、背景、目的、手法、処理の事例を紹介する
- 1文を短く、改行を多めに

#111〜#114 で構造は完成しましたが、「なぜこの層があるのか」「どう使うのか」はコードの外に記録されていませんでした。

## What Changed

### 各レイヤークレートに README.md を新設

4つとも同じ構成 (概要 / 背景 / 目的 / 手法 / 処理の事例 / 依存) で書いています:

- `crates/domain/README.md` — VO の一覧表と parse-don't-validate の説明。受理する時刻形式 3 種を明記
- `crates/usecase/README.md` — DST が生む2つの特殊ケース (曖昧な時刻・存在しない時刻) という「このクレートの存在理由」を中心に
- `crates/infrastructure/README.md` — 3つの情報源の優先順位と、全滅時に panic する理由
- `crates/presentation/README.md` — 処理の一直線フローと「検証ロジックはこの層にない」という設計判断

### ルート README に Architecture 節を追加

- クレート表 + 各 README へのリンク
- 依存方向が一方向であることの明記

## Tradeoffs and Limitations

- **クレート README は日本語、ルート README は英語のまま**: ルートは公開ページなので既存の英語を維持し、内部ガイドはメンテナ (日本語話者) 向けに最適化しました
- **内容の二重管理リスク**: コードが変わったら README も追従が必要です。形式を「事例中心」にして、腐りにくい記述を心がけています

## Testing

ドキュメントのみの変更です。全31テストがパスすることを確認済み (コード差分ゼロ)。

## Review Guide

1. `crates/usecase/README.md` — 「背景」の書き方が意図通りか確認してください (他の3つも同じトーンです)
2. ルート `README.md` の Architecture 節 — 公開ページに載る部分です

🤖 Generated with [Claude Code](https://claude.com/claude-code)