### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "tzt"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tzt"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "simple command-line utility that converts a given time from one timezone to another."


### PR DESCRIPTION
## Summary

- `Cargo.toml` の package.version を `0.3.1` → `0.4.0` にバンプ
- `cargo build` で `Cargo.lock` を再生成

## Background

0.4.0 は大規模リファクタ (#111〜#116) を取り込む最初のリリースです:

- Clean Architecture レイヤー構造 (domain / usecase / infrastructure / presentation)
- バリューオブジェクトによる parse-don't-validate
- AAA + Fixture のテスト体系、リーダブルコード適用
- CLI の振る舞いは 0.3.1 と完全互換 (minor bump の理由は内部構造の全面刷新)

crates.io には 0.3.1 が既に存在するため、publish にはこの版上げが必要です。
CLI の `--version` は `CARGO_PKG_VERSION` を参照しており、本変更だけで `0.4.0` を表示します (確認済み)。

## Test plan

- [x] `cargo build` 成功・`tzt --version` が `0.4.0` を表示
- [x] CI (build/test) が green
- [ ] merge 後に `cargo publish` で crates.io へ 0.4.0 を公開

🤖 Generated with [Claude Code](https://claude.com/claude-code)