### PR TITLE
chore(deps): bump clap from 4.5 to 4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -56,17 +56,18 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,18 +145,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -165,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -272,6 +273,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "phf"
@@ -536,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -547,6 +554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4"
 chrono-tz = "0.10"
 # feature "string": lets Arg::default_value take an owned String, so the
 # runtime-detected local timezone needs no Box::leak / &'static str hack
-clap = { version = "4.5", features = ["string"] }
+clap = { version = "4.6", features = ["string"] }
 regex = "1.12.2"
 thiserror = "2.0.18"
 


### PR DESCRIPTION
## 概要

`clap` を 4.5 から 4.6 へ更新する。stale な dependabot PR #110 がビルド失敗していた問題を、現行 main を基点にしたクリーンな bump で解消する。#110 の代替。

## 背景

dependabot の PR #110 (2026-04-01 作成) は当時の main を基点にしていた。その後 main の `clap` 宣言が feature `"string"` 付き (`clap = { version = "4.5", features = ["string"] }`) に変わった。#110 は素朴に `clap = "4.6"` を `[dependencies]` へ追記していたため、feature 付きの既存宣言と重複し、`Cargo.toml:21: duplicate key` でビルドが落ちていた。

## 課題

- #110 の Build and Test が macOS / Ubuntu 双方で `duplicate key` により失敗 (exit 101)
- dependabot ブランチを直接 rebase/force-push すると dependabot の管理と競合する

## 目標

- 必須: `clap` を 4.6 に更新しつつ feature `"string"` を維持する
- 必須: build / clippy / test が通ること
- 範囲外: 他の依存の更新 (Cargo.lock の追従分を除く)

## 採用手法

| 選択肢 | 内容 | 採否 |
|---|---|---|
| 現行 main から新ブランチでクリーン bump | feature を保ったまま version のみ 4.6 へ | 採用。壊れた古い差分を持ち込まない |
| #110 を rebase して修正 | dependabot ブランチを直接編集 | 不採用。force-push が必要で dependabot と競合 |

## 変更箇所

- `Cargo.toml`: `clap` を `4.6` に更新 (`features = ["string"]` は維持)
- `Cargo.lock`: `clap` 4.5.56 → 4.6.1、および anstream/anstyle/clap_lex 系を追従

## 妥協と制限

- 無し。

## 検証方法

- `cargo build --verbose` 成功
- `cargo clippy --verbose` 警告なし
- `cargo test --verbose` — unit 22 / CLI 統合 9 すべて pass

## 確認事項

- ⚠️ 本 PR がマージされたら stale な #110 はクローズする想定。

## 参考文献

- 置き換え対象: #110 (Bump clap from 4.5.56 to 4.6.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)