### PR TITLE
ci: auto-merge non-major dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,25 @@ updates:
     # 更新 PR を作らない (zizmor: insufficient-cooldown 対策)。
     cooldown:
       default-days: 7
+    # minor と patch をそれぞれ 1 本の PR にまとめる。major はグループに載らず
+    # 個別 PR のままになるため、auto-merge (非 major のみ) と両立する。
+    groups:
+      minor:
+        update-types:
+          - "minor"
+      patch:
+        update-types:
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      minor:
+        update-types:
+          - "minor"
+      patch:
+        update-types:
+          - "patch"

--- a/.github/workflows/dependabot__automerge.yaml
+++ b/.github/workflows/dependabot__automerge.yaml
@@ -1,0 +1,37 @@
+name: dependabot__automerge
+
+# 非 major の dependabot PR を auto-merge する。実際のマージは main ruleset の
+# required_status_checks が全通過してから GitHub が行う (即マージにはならない)。
+# major 更新は破壊的変更を含みうるため人間のレビューを残す。
+
+on:
+  pull_request:
+    branches: [main]
+
+# 既定は最小権限。auto-merge の有効化に必要な権限は job 側で付与する。
+permissions:
+  contents: read
+
+jobs:
+  automerge:
+    # dependabot が作成した PR のみを対象にする。github.actor は spoofable なため、
+    # pull_request イベントで信頼できる PR 作成者 (user.login) で判定する。
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      # auto-merge の有効化に必要。
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      # major 以外 (minor / patch) のみ auto-merge を有効化する。
+      - name: Enable auto-merge for non-major updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "${PR_URL}"


### PR DESCRIPTION
## 概要

非 major の dependabot 更新 (minor / patch) を CI 通過後に自動マージする。併せて github-actions エコシステムも dependabot の監視対象に加える。major 更新は破壊的変更を含みうるため人間のレビューを残す。

## 背景

これまで dependabot 更新はすべて手動マージしていた。日常的な minor / patch 更新まで手で捌くのは負担で、放置すると PR が溜まる。一方 major は破壊的変更を含みうるので自動化したくない。「非 major は自動、major は手動」に運用を分けたい。

auto-merge の前提となる `allow_auto_merge` の有効化と main ruleset への `required_status_checks` 追加は、リポジトリ設定の source of truth である github_central 側の PR (shunsock/github_central#5) で apply 済み。本 PR はリポジトリ固有の dependabot 設定と自動マージ workflow を追加する。

## 課題

- minor / patch の更新 PR を毎回手動マージしており負担が大きい
- github-actions の action バージョンが dependabot の監視対象に入っておらず、SHA 更新が手動
- 「非 major だけ自動、major は手動」を安全に (CI 通過を待って) 実現する必要がある

## 目標

- 必須: minor / patch の dependabot PR を CI 全通過後に auto-merge する
- 必須: major PR は auto-merge せず手動レビューに残す
- 必須: github-actions エコシステムを cooldown 付きで監視対象に加える
- 範囲外: `allow_auto_merge` / ruleset の設定 (github_central#5 で対応済み)

## 採用手法

auto-merge は dependabot.yml 単体では実現できないため、`dependabot/fetch-metadata` を使う workflow で「更新種別が major 以外」のときだけ `gh pr merge --auto` を呼ぶ。実マージは main ruleset の必須チェック通過後に GitHub 側が行うため、CI を待たずに即マージされることはない。

major を除外する仕組みはグルーピングとも噛み合う。minor / patch をそれぞれ group 化する一方、major は group に載らず個別 PR のまま残る。group PR の `update-type` は同種のみなので、fetch-metadata の判定と矛盾しない。

| 選択肢 | 内容 | 採否 |
|---|---|---|
| fetch-metadata + `gh pr merge --auto` | 更新種別で分岐し非 major のみ auto-merge | 採用。公式が案内する定石で、CI gating と両立 |
| 全更新を無条件 auto-merge | workflow を単純化 | 不採用。major の破壊的変更を見逃す |
| dependabot.yml だけで完結 | 追加 workflow なし | 不採用。dependabot.yml に auto-merge 指定は存在しない |

PR 作成者の判定には spoofable な `github.actor` ではなく、pull_request イベントで信頼できる `github.event.pull_request.user.login` を使う (zizmor bot-conditions)。

## 変更箇所

- `.github/dependabot.yml`:
  - `github-actions` ecosystem を追加 (monthly, cooldown 7 days)
  - cargo / github-actions の双方で minor・patch を group 化
- `.github/workflows/dependabot__automerge.yaml` (新規):
  - dependabot PR で fetch-metadata を読み、非 major のみ `gh pr merge --auto --merge`
  - 最小権限 (job で contents/pull-requests: write)、timeout 5 分、fetch-metadata を SHA 固定

## 妥協と制限

- 実マージのタイミングは GitHub の auto-merge に委ねる。必須チェックが将来増減した場合は github_central 側 ruleset の追随が必要。
- group PR に major が混ざらない前提 (minor/patch のみ group 化) に依存する。

## 検証方法

- `actionlint` / `ghalint` / `zizmor` をローカル実行し、workflow が全て pass することを確認
- `yamllint` で dependabot.yml の構文を確認
- CI (lint__github_actions) で workflow 静的解析が通ることを確認

## 確認事項

- ⚠️ 本 PR の workflow は dependabot 以外の PR では job が skip される (この PR 自身でも skip)。実際の auto-merge 挙動は次回の dependabot PR で確認する。
- ⚠️ auto-merge の前提設定は github_central#5 の apply に依存する。apply 完了後に有効。

## 参考文献

- 前提設定 PR: shunsock/github_central#5
- [Automating Dependabot with GitHub Actions (公式)](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
